### PR TITLE
Help text tweaks

### DIFF
--- a/source/jaster/cli/core.d
+++ b/source/jaster/cli/core.d
@@ -722,10 +722,6 @@ final class CommandLineInterface(Modules...)
 
         CommandExecuteFunc createCommandExecuteFunc(alias T)()
         {
-            import std.format    : format;
-            import std.algorithm : filter, map;
-            import std.exception : enforce, collectException;
-
             // This is expecting the parser to have already read in the command's name, leaving only the args.
             return (ArgPullParser parser, ref string executionError, scope ref ServiceScope services, HelpTextBuilderSimple helpText)
             {

--- a/source/jaster/cli/core.d
+++ b/source/jaster/cli/core.d
@@ -1065,7 +1065,7 @@ final class CommandLineInterface(Modules...)
                            command.finalWords
                                   .uniq!((a, b) => a.userData.pattern == b.userData.pattern)
                                   .map!(c => HelpSectionArgInfoContent.ArgInfo(
-                                       [c.word],
+                                       [c.userData.pattern.pattern.splitter('|').front],
                                        c.userData.pattern.description,
                                        ArgIsOptional.no
                                   ))

--- a/source/jaster/cli/core.d
+++ b/source/jaster/cli/core.d
@@ -920,6 +920,9 @@ final class CommandLineInterface(Modules...)
                             {
                                 PositionalArgInfo!T arg;
                                 arg.uda = getSingleUDA!(Symbol, CommandPositionalArg);
+
+                                if(arg.uda.name.length == 0)
+                                    arg.uda.name = "VALUE";
                             }
                             else static assert(false, "Bug with parent if statement.");
 

--- a/source/jaster/cli/core.d
+++ b/source/jaster/cli/core.d
@@ -496,7 +496,6 @@ final class CommandLineInterface(Modules...)
                     "Multiple default commands defined: Second default command is %s"
                     .format(T.stringof)
                 );
-                info.helpText.setCommandName("DEFAULT");
                 this._defaultCommand = info;
             }
             else
@@ -662,7 +661,7 @@ final class CommandLineInterface(Modules...)
                 );
             }
 
-            builder.commandName = UDA.pattern;
+            builder.commandName = this._appName ~ " " ~ UDA.pattern;
             builder.description = UDA.description;
 
             return builder;

--- a/source/jaster/cli/core.d
+++ b/source/jaster/cli/core.d
@@ -659,7 +659,7 @@ final class CommandLineInterface(Modules...)
                         case Text:
                             if(positionalArgIndex >= positionalArgs.length)
                             {
-                                executionError = "Stray positional arg found: '"~token.value~"'";
+                                executionError = "too many arguments starting at '"~token.value~"'";
                                 return -1;
                             }
 

--- a/source/jaster/cli/core.d
+++ b/source/jaster/cli/core.d
@@ -860,7 +860,7 @@ final class CommandLineInterface(Modules...)
                     case Text:
                         if(positionalArgIndex >= positionalArgs.length)
                         {
-                            executionError = "Stray positional arg found: '"~token.value~"'";
+                            executionError = "too many arguments starting at '"~token.value~"'";
                             return false;
                         }
 

--- a/source/jaster/cli/core.d
+++ b/source/jaster/cli/core.d
@@ -292,6 +292,22 @@ ServiceInfo[] addCommandLineInterfaceService(ref ServiceInfo[] services)
  +  For example, you have the following member in a command `@CommandRawArg string[] rawList;`, and you are given the following command - 
  +  `["command", "value1", "--", "rawValue1", "rawValue2"]`, which will result in `rawList`'s value becoming `["rawValue1", "rawValue2"]`
  +
+ + Arguments_Groups:
+ +  Arguments can be grouped together so they are displayed in a more logical manner within your command's help text.
+ +
+ +  The recommended way to make an argument group, is to create an `@CommandArgGroup` UDA block:
+ +
+ +  ```
+ +  @CommandArgGroup("Debug", "Flags relating the debugging.")
+ +  {
+ +      @CommandNamedArg("trace|t", "Enable tracing") Nullable!bool trace;
+ +      ...
+ +  }
+ +  ```
+ +
+ +  While you *can* apply the UDA individually to each argument, there's one behaviour that you should be aware of - the group's description
+ +  as displayed in the help text will use the description of the $(B last) found `@CommandArgGroup` UDA.
+ +
  + Params:
  +  Modules = The modules that contain the commands and/or binder funcs to use.
  + +/

--- a/source/jaster/cli/helptext.d
+++ b/source/jaster/cli/helptext.d
@@ -272,7 +272,7 @@ final class HelpTextBuilderSimple
             this._positionalArgs ~= PositionalArg(
                 position,
                 HelpSectionArgInfoContent.ArgInfo(
-                    [position.to!string] ~ ((displayName is null) ? [] : [displayName]),
+                    (displayName is null) ? [] : [displayName],
                     description,
                     isOptional
                 )
@@ -337,11 +337,11 @@ final class HelpTextBuilderSimple
                            this._positionalArgs
                                 .tee!((p)
                                 {
-                                    auto text = "{%s}".format(p.info.names.joiner("/"));
-
+                                    // Using git as a precedant for the angle brackets.
+                                    auto name = "%s".format(p.info.names.joiner("/"));
                                     usageString ~= (p.info.isOptional)
-                                                    ? "<"~text~">"
-                                                    : text;
+                                                    ? "["~name~"]"
+                                                    : "<"~name~">";
                                     usageString ~= ' ';
                                 })
                                 .map!(p => p.info)
@@ -358,11 +358,15 @@ final class HelpTextBuilderSimple
                            this._namedArgs
                                .tee!((a)
                                {
-                                    auto text = "[%s]".format(a.names.joiner("|"));
+                                    auto name = "%s".format(
+                                        a.names
+                                         .map!(n => (n.length == 1) ? "-"~n : "--"~n)
+                                         .joiner("|")
+                                    );
 
                                     usageString ~= (a.isOptional)
-                                                    ? "<"~text~">"
-                                                    : text;
+                                                    ? "["~name~"]"
+                                                    : name;
                                     usageString ~= ' ';
                                })
                                .array,
@@ -388,14 +392,14 @@ unittest
            .setDescription("This is a command that transforms the InputFile into an OutputFile");
 
     assert(builder.toString() == 
-        "Usage: MyCommand {0/InputFile} {1/OutputFile} <[v|verbose]> \n"
+        "Usage: MyCommand <InputFile> <OutputFile> [-v|--verbose] \n"
        ~"\n"
        ~"Description:\n"
        ~"    This is a command that transforms the InputFile into an OutputFile\n"
        ~"\n"
        ~"Positional Args:\n"
-       ~"    0,InputFile                  - The input file.\n"
-       ~"    1,OutputFile                 - The output file.\n"
+       ~"    InputFile                    - The input file.\n"
+       ~"    OutputFile                   - The output file.\n"
        ~"\n"
        ~"Named Args:\n"
        ~"    -v,--verbose                 - Verbose output",

--- a/source/jaster/cli/helptext.d
+++ b/source/jaster/cli/helptext.d
@@ -247,6 +247,7 @@ final class HelpTextBuilderSimple
         struct ArgGroup
         {
             string name;
+            string description;
             NamedArg[] named;
             PositionalArg[] positional;
 
@@ -325,6 +326,13 @@ final class HelpTextBuilderSimple
         HelpTextBuilderSimple addPositionalArg(size_t position, string description, ArgIsOptional isOptional, string displayName = null)
         {
             return this.addPositionalArg(null, position, description, isOptional, displayName);
+        }
+
+        ///
+        HelpTextBuilderSimple setGroupDescription(string group, string description)
+        {
+            this.groupByName(group).description = description;
+            return this;
         }
 
         ///
@@ -431,6 +439,9 @@ final class HelpTextBuilderSimple
                 {
                     scope section = &builder.addSection(group.name);
                     assert(section !is null);
+
+                    if(group.description !is null)
+                        section.addContent(new HelpSectionTextContent(group.description~"\n\n"));
                     writePositionalArgs(*section, group.positional);
                     writeNamedArgs(*section, group.named);
                 }
@@ -451,7 +462,8 @@ unittest
            .addNamedArg(["v","verbose"], "Verbose output", ArgIsOptional.yes)
            .addNamedArg("Utility", "encoding", "Sets the encoding to use.", ArgIsOptional.yes)
            .setCommandName("MyCommand")
-           .setDescription("This is a command that transforms the InputFile into an OutputFile");
+           .setDescription("This is a command that transforms the InputFile into an OutputFile")
+           .setGroupDescription("Utility", "Utility arguments used to modify the output.");
 
     assert(builder.toString() == 
         "Usage: MyCommand <InputFile> <OutputFile> [-v|--verbose] [--encoding] \n"
@@ -467,6 +479,8 @@ unittest
        ~"    -v,--verbose                 - Verbose output\n"
        ~"\n"
        ~"Utility:\n"
+       ~"    Utility arguments used to modify the output.\n"
+       ~"\n"
        ~"    --encoding                   - Sets the encoding to use.",
 
         "\n"~builder.toString()

--- a/source/jaster/cli/helptext.d
+++ b/source/jaster/cli/helptext.d
@@ -211,6 +211,7 @@ final class HelpTextBuilderTechnical
                     
                 output ~= section.name~":\n";
                 section.content.map!(c => c.getContent(section.options))
+                               .joiner("\n")
                                .each!(c => output ~= c);
             }
 
@@ -441,7 +442,7 @@ final class HelpTextBuilderSimple
                     assert(section !is null);
 
                     if(group.description !is null)
-                        section.addContent(new HelpSectionTextContent(group.description~"\n\n"));
+                        section.addContent(new HelpSectionTextContent(group.description~"\n"));
                     writePositionalArgs(*section, group.positional);
                     writeNamedArgs(*section, group.named);
                 }
@@ -459,6 +460,7 @@ unittest
 
     builder.addPositionalArg(0, "The input file.", ArgIsOptional.no, "InputFile")
            .addPositionalArg(1, "The output file.", ArgIsOptional.no, "OutputFile")
+           .addPositionalArg("Utility", 2, "How much to compress the file.", ArgIsOptional.no, "CompressionLevel")
            .addNamedArg(["v","verbose"], "Verbose output", ArgIsOptional.yes)
            .addNamedArg("Utility", "encoding", "Sets the encoding to use.", ArgIsOptional.yes)
            .setCommandName("MyCommand")
@@ -466,7 +468,7 @@ unittest
            .setGroupDescription("Utility", "Utility arguments used to modify the output.");
 
     assert(builder.toString() == 
-        "Usage: MyCommand <InputFile> <OutputFile> [-v|--verbose] [--encoding] \n"
+        "Usage: MyCommand <InputFile> <OutputFile> [-v|--verbose] <CompressionLevel> [--encoding] \n"
        ~"\n"
        ~"Description:\n"
        ~"    This is a command that transforms the InputFile into an OutputFile\n"
@@ -481,6 +483,7 @@ unittest
        ~"Utility:\n"
        ~"    Utility arguments used to modify the output.\n"
        ~"\n"
+       ~"    CompressionLevel             - How much to compress the file.\n"
        ~"    --encoding                   - Sets the encoding to use.",
 
         "\n"~builder.toString()

--- a/source/jaster/cli/helptext.d
+++ b/source/jaster/cli/helptext.d
@@ -518,7 +518,7 @@ final class HelpSectionArgInfoContent : IHelpSectionContent
     string getContent(const HelpSectionOptions options)
     {
         import std.array     : array;
-        import std.algorithm : map, reduce, count, max, splitter, substitute;
+        import std.algorithm : map, fold, count, max, splitter, substitute;
         import std.conv      : to;
         import std.exception : assumeUnique;
         import std.utf       : byChar;
@@ -554,7 +554,7 @@ final class HelpSectionArgInfoContent : IHelpSectionContent
                                      ? (n.length == 1) ? "-"~n : "--"~n
                                      : n
                          )
-                         .reduce!((a, b) => a~","~b)
+                         .fold!((a, b) => a~","~b)("")
                          .byChar
                          .array
             );

--- a/source/jaster/cli/helptext.d
+++ b/source/jaster/cli/helptext.d
@@ -518,7 +518,7 @@ final class HelpSectionArgInfoContent : IHelpSectionContent
     string getContent(const HelpSectionOptions options)
     {
         import std.array     : array;
-        import std.algorithm : map, fold, count, max, splitter, substitute;
+        import std.algorithm : map, reduce, filter, count, max, splitter, substitute;
         import std.conv      : to;
         import std.exception : assumeUnique;
         import std.utf       : byChar;
@@ -554,7 +554,8 @@ final class HelpSectionArgInfoContent : IHelpSectionContent
                                      ? (n.length == 1) ? "-"~n : "--"~n
                                      : n
                          )
-                         .fold!((a, b) => a~","~b)("")
+                         .filter!(n => n.length > 0)
+                         .reduce!((a, b) => a~","~b)
                          .byChar
                          .array
             );


### PR DESCRIPTION
I'll start updating the README PR at another point in time (probably after I get most of the other feature suggestions done).

# Command help text with every current feature.

JCLI will auto wrap text, so the Lorem Ipsum snippet was just to show what it looks like.

```bash
Usage: tool.exe complex <file> <output> --iterations|-i --config|-c [--verbose|-v]

Description:
    This is a super complex command.

Positional Args:
    file                         - A file to do... stuff with.

Named Args:
    --iterations,-i              - How many iterations of a thing to do.
    --verbose,-v                 - Toggle verbose output.

IO Flags:
    Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna
    aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat.
    Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur si
    nt occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.

    output                       - The output file path.
    --config,-c                  - Path to the config file.
```

# No command given. (Same as commandless `--help` except it also has an error.)

```bash
tool.exe: No command was given.
Available commands:
    complex                      - This is a super complex command.
    sub one                      - This is the first sub command.
    sub two                      - This is the other sub command.
```

# Unknown command.

```bash
tool.exe: Unknown command 'bad'.
Did you mean:
    complex                      - This is a super complex command.
    sub one                      - This is the first sub command.
    sub two                      - This is the other sub command.
```

# Unknown command (partial match). (Same as partial match `--help` except is also has an error.)

```bash
tool.exe: Unknown command 'sub'.
Did you mean:
    sub one                      - This is the first sub command.
    sub two                      - This is the other sub command.
```

# Too many positional args

```bash
Running .\tool.exe complex a b c
tool.exe: too many arguments starting at 'c'
```

# Missing required args

```bash
Running .\tool.exe complex
tool.exe: Missing required arguments --iterations, --config, <file>, <output>
```

# Unknown named arg

```bash
Running .\tool.exe complex --nan
tool.exe: Unknown named argument: 'nan'
```

# Invalid conversion

**This needs to be changed** but it'd probably be tied into #12 rather than this PR.

```bash
Running .\tool.exe complex a a --iterations number

std.conv.ConvException@G:\None-Game\D\tools\dmd2\windows\bin\..\..\src\phobos\std\conv.d(2378): Unexpected 'n' when converting from type string to type int
```

# Command throws uncaught exception

Stack traces are only displayed in debug builds.

```
Running .\tool.exe sub one
tool.exe: This is an error message.

STACK TRACE:
0x00007FF680A583A0 in app.SubCommand1.onExecute at G:\None-Game\D\tools\dmd2\windows\bin\..\..\src\druntime\import\object.d(2058)
...
```

# Validation failed

```
Running .\tool.exe sub two a
tool.exe: For positional arg 0(input): Validation error message here
```

```
Running .\tool.exe sub two --input a
tool.exe: For named argument input: Validation error message here
```

# Conclusion

I think those are all the unique states JCLI will display messages? Probably missed a few.