### PR TITLE
Implement `@CommandDefault`

### DIFF
--- a/.github/workflows/test_examples.yaml
+++ b/.github/workflows/test_examples.yaml
@@ -1,5 +1,4 @@
-on:
-  push
+on: [push, pull_request]
 
 name: Test Examples
 
@@ -11,7 +10,7 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v2
       - name: Setup LDC
-        uses: mihails-strasuns/setup-dlang@v0.3.0
+        uses: dlang-community/setup-dlang@v1
         with:
           compiler: ldc-latest
       - name: "Run tests"

--- a/.github/workflows/test_ldc.yaml
+++ b/.github/workflows/test_ldc.yaml
@@ -1,5 +1,4 @@
-on:
-  push
+on: [push, pull_request]
 
 name: Test LDC x64
 
@@ -11,7 +10,7 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v2
       - name: Setup LDC
-        uses: mihails-strasuns/setup-dlang@v0.3.0
+        uses: dlang-community/setup-dlang@v1
         with:
           compiler: ldc-latest
       - name: Build

--- a/examples/00-basic-usage-default-command/source/commands.d
+++ b/examples/00-basic-usage-default-command/source/commands.d
@@ -3,10 +3,7 @@ module commands;
 import jaster.cli;
 
 // Use either a struct or class. JCLI supports both (including inheritence).
-//
-// Passing `null` as the name will create the "default" command - the command that is ran if no sub-command is specified.
-// e.g. "mytool.exe param1 --param2" would execute the default command.
-@Command(null, "Asserts that the given number is even.")
+@CommandDefault("Asserts that the given number is even.")
 struct AssertEvenCommand
 {
     // Positional args are args that aren't defined by a command line flag.

--- a/examples/04-custom-arg-binders/source/commands.d
+++ b/examples/04-custom-arg-binders/source/commands.d
@@ -3,7 +3,7 @@ module commands;
 import std.stdio : writeln, File;
 import jaster.cli;
 
-@Command(null, "Displays the contents of a file.")
+@CommandDefault("Displays the contents of a file.")
 class CatCommand
 {
     // Because this is of type `File`, JCLI will use our custom arg binder (in binders.d) to perform the conversion.

--- a/examples/05-dependency-injection/source/commands.d
+++ b/examples/05-dependency-injection/source/commands.d
@@ -4,7 +4,7 @@ import std.stdio : writeln, File;
 import jaster.cli;
 import services;
 
-@Command(null, "Determines if your password is correct.")
+@CommandDefault("Determines if your password is correct.")
 class PasswordCommand
 {
     private IPasswordManager _passwords;

--- a/examples/08-arg-binder-validation/source/commands.d
+++ b/examples/08-arg-binder-validation/source/commands.d
@@ -35,7 +35,7 @@ struct Is
     }
 }
 
-@Command(null)
+@CommandDefault
 struct DefaultCommand
 {
     @CommandPositionalArg(0, "Even", "Should be even")

--- a/examples/09-raw-unparsed-arg-list/source/commands.d
+++ b/examples/09-raw-unparsed-arg-list/source/commands.d
@@ -16,7 +16,7 @@ and then this variable's value will contain the entirety of the raw arg list.
 
 ++/
 
-@Command(null, "Runs a command with the given arguments.")
+@CommandDefault("Runs a command with the given arguments.")
 struct RunCommand
 {
     @CommandPositionalArg(0, "command", "The command to run.")

--- a/examples/test.d
+++ b/examples/test.d
@@ -189,7 +189,7 @@ int main(string[] args)
 }
 
 /++ COMMANDS ++/
-@Command(null, "Runs all test cases")
+@CommandDefault("Runs all test cases")
 struct DefaultCommand
 {
     int onExecute()

--- a/source/jaster/cli/core.d
+++ b/source/jaster/cli/core.d
@@ -923,7 +923,7 @@ final class CommandLineInterface(Modules...)
             CommandArguments!T commandArgs = getArgs!T;
 
             CommandInfo info;
-            info.helpText   = createHelpText!T(commandArgs);
+            info.helpText   = createHelpText!T(this._appName, commandArgs);
             info.doExecute  = createCommandExecuteFunc!T(commandArgs);
             info.doComplete = createCommandCompleteFunc!T(commandArgs);
 

--- a/source/jaster/cli/core.d
+++ b/source/jaster/cli/core.d
@@ -33,6 +33,18 @@ struct Command
 }
 
 /++
+ + Attach this to any struct/class that represents the default command.
+ +
+ + See_Also:
+ +  `jaster.cli
+ + ++/
+struct CommandDefault
+{
+    /// The description of this command.
+    string description;
+}
+
+/++
  + Attach this to any member field to mark it as a named argument.
  +
  + See_Also:
@@ -44,18 +56,6 @@ struct CommandNamedArg
     string pattern;
 
     /// The description of this argument.
-    string description;
-}
-
-/++
- + Attach this to any struct/class that represents the default command.
- +
- + See_Also:
- +  `jaster.cli
- + ++/
-struct CommandDefault
-{
-    /// The description of this command.
     string description;
 }
 
@@ -189,16 +189,9 @@ private struct CommandInfo
 }
 
 /+ COMMAND INFO CREATOR FUNCTIONS +/
-private HelpTextBuilderSimple createHelpText(alias T)(string appName, in CommandArguments!T commandArgs)
+private HelpTextBuilderSimple createHelpText(T, Command UDA)(string appName, in CommandArguments!T commandArgs)
 {
-    import std.algorithm : splitter;
     import std.array     : array;
-
-    // Get UDA
-    static if(hasUDA!(T, Command))
-        enum UDA = getSingleUDA!(T, Command);
-    else
-        enum UDA = Command(null, getSingleUDA!(T, CommandDefault).description);
 
     auto builder = new HelpTextBuilderSimple();
 
@@ -461,7 +454,7 @@ private bool onExecuteValidateArgs(alias T)(
     import std.algorithm : filter, map;
     import std.format    : format;
     import std.exception : assumeUnique;
-  
+
     char[] error;
     error.reserve(512);
 
@@ -487,7 +480,7 @@ private bool onExecuteValidateArgs(alias T)(
             error ~= ">, ";
         }
     }
-  
+
     if(error.length > 0)
     {
         error = error[0..$-2]; // Skip extra ", "
@@ -726,6 +719,19 @@ private void insertRawList(T)(ref T command, string[] rawList)
  + +/
 final class CommandLineInterface(Modules...)
 {
+    private alias defaultCommands = getSymbolsByUDAInModules!(CommandDefault, Modules);
+    static assert(defaultCommands.length <= 1, "Multiple default commands defined " ~ defaultCommands.stringof);
+
+    static if(defaultCommands.length > 0)
+    {
+        static assert(is(defaultCommands[0] == struct) || is(defaultCommands[0] == class),
+            "Only structs and classes can be marked with @CommandDefault. Issue Symbol = " ~ __traits(identifier, defaultCommands[0])
+        );
+        static assert(!hasUDA!(defaultCommands[0], Command),
+            "Both @CommandDefault and @Command are used for symbol " ~ __traits(identifier, defaultCommands[0])
+        );
+    }
+
     alias ArgBinderInstance     = ArgBinder!Modules;
     immutable BASH_COMPLETION   = import("bash_completion.sh");
 
@@ -758,7 +764,7 @@ final class CommandLineInterface(Modules...)
     {
         CommandResolver!CommandInfo _resolver;
         ServiceProvider             _services;
-        CommandInfo                 _defaultCommand;
+        Nullable!CommandInfo        _defaultCommand;
         string                      _appName;
     }
 
@@ -788,6 +794,8 @@ final class CommandLineInterface(Modules...)
             this._services = services;
             this._resolver = new CommandResolver!CommandInfo();
             this._appName  = appName;
+
+            addDefaultCommand();
 
             static foreach(mod; Modules)
                 this.addCommandsFromModule!mod();
@@ -833,7 +841,7 @@ final class CommandLineInterface(Modules...)
             import std.stdio     : writefln;
             import std.format    : format;
 
-            if(args.empty && this._defaultCommand == CommandInfo.init)
+            if(args.empty && this._defaultCommand.isNull)
             {
                 writefln(this.makeErrorf("No command was given."));
                 writefln(this.createAvailableCommandsHelpText(args, "Available commands").toString());
@@ -858,20 +866,20 @@ final class CommandLineInterface(Modules...)
                 if(args.containsHelpArgument())
                 {
                     parseResult.type = ParseResultType.showHelpText;
-                    if(this._defaultCommand != CommandInfo.init)
-                        parseResult.helpText ~= this._defaultCommand.helpText.toString();
-                    
+                    if(!this._defaultCommand.isNull)
+                        parseResult.helpText ~= this._defaultCommand.get.helpText.toString();
+
                     if(this._resolver.finalWords.length > 0)
                         parseResult.helpText ~= this.createAvailableCommandsHelpText(parseResult.argParserBeforeAttempt, "Available commands").toString();
                 }
-                else if(this._defaultCommand == CommandInfo.init)
+                else if(this._defaultCommand.isNull)
                 {
                     parseResult.type      = ParseResultType.commandNotFound;
                     parseResult.helpText ~= this.makeErrorf("Unknown command '%s'.\n", parseResult.argParserBeforeAttempt.front.value);
                     parseResult.helpText ~= this.createAvailableCommandsHelpText(parseResult.argParserBeforeAttempt).toString();
                 }
                 else
-                    parseResult.command = this._defaultCommand;
+                    parseResult.command = this._defaultCommand.get;
             }
             else
                 parseResult.command = result.value.userData;
@@ -896,56 +904,48 @@ final class CommandLineInterface(Modules...)
     /+ COMMAND DISCOVERY AND REGISTRATION +/
     private final
     {
-        void addCommandsFromModule(alias Module)()
+        void addDefaultCommand()
         {
-            import std.traits : getSymbolsByUDA;
-            import std.meta   : AliasSeq;
-
-            static foreach(symbol; AliasSeq!(getSymbolsByUDA!(Module, Command), getSymbolsByUDA!(Module, CommandDefault)))
+            static if(defaultCommands.length > 0)
             {
-                static assert(is(symbol == struct) || is(symbol == class), 
-                    "Only structs and classes can be marked with @Command. Issue Symbol = " ~ __traits(identifier, symbol)
-                );
+                enum UDA = Command("DEFAULT", getSingleUDA!(defaultCommands[0], CommandDefault).description);
 
-                pragma(msg, "Found command: ", __traits(identifier, symbol));
-                this.addCommand!symbol();
+                _defaultCommand = getCommand!(defaultCommands[0], UDA);
             }
         }
 
-        void addCommand(alias T)()
-        if(is(T == struct) || is(T == class))
+        void addCommandsFromModule(alias Module)()
         {
-            import std.algorithm : splitter;
-            import std.format    : format;
-            import std.exception : enforce;
-          
-            // Get arg info.
-            CommandArguments!T commandArgs = getArgs!T;
+            import std.traits : getSymbolsByUDA;
 
-            CommandInfo info;
-            info.helpText   = createHelpText!T(this._appName, commandArgs);
-            info.doExecute  = createCommandExecuteFunc!T(commandArgs);
-            info.doComplete = createCommandCompleteFunc!T(commandArgs);
+            static foreach(symbol; getSymbolsByUDA!(Module, Command))
+            {{
+                static assert(is(symbol == struct) || is(symbol == class),
+                    "Only structs and classes can be marked with @Command. Issue Symbol = " ~ __traits(identifier, symbol)
+                );
 
-            static if(hasUDA!(T, Command))
-            {
-                enum UDA = getSingleUDA!(T, Command);
+                enum UDA = getSingleUDA!(symbol, Command);
                 static assert(UDA.pattern !is null, "Null command names are deprecated, please use `@CommandDefault` instead.");
+
+                auto info = getCommand!(symbol, UDA);
                 info.pattern = UDA;
 
                 foreach(pattern; info.pattern.pattern.byPatternNames)
                     this._resolver.define(pattern, info);
-            }
-            else static if(hasUDA!(T, CommandDefault))
-            {
-                enforce(
-                    this._defaultCommand == CommandInfo.init, 
-                    "Multiple default commands defined: Second default command is %s"
-                    .format(T.stringof)
-                );
-                this._defaultCommand = info;
-            }
-            else static assert(false, "This shouldn't happen.");
+            }}
+        }
+
+        CommandInfo getCommand(T, Command UDA)()
+        {
+            // Get arg info.
+            CommandArguments!T commandArgs = getArgs!T;
+
+            CommandInfo info;
+            info.helpText   = createHelpText!(T, UDA)(this._appName, commandArgs);
+            info.doExecute  = createCommandExecuteFunc!T(commandArgs);
+            info.doComplete = createCommandCompleteFunc!T(commandArgs);
+
+            return info;
         }
     }
 
@@ -1522,7 +1522,7 @@ version(unittest)
             ) == -1
         );
     }
-  
+
     @Command("arg group test", "Test arg groups work")
     private struct ArgGroupTestCommand
     {

--- a/source/jaster/cli/udas.d
+++ b/source/jaster/cli/udas.d
@@ -11,7 +11,14 @@ template getSingleUDA(alias Symbol, alias UDA)
 {
     import std.traits : getUDAs;
 
-    enum UDAs = getUDAs!(Symbol, UDA);
+    // Check if they created an instance `@UDA()`
+    //
+    // or if they just attached the type itself `@UDA`
+    static if(__traits(compiles, {enum UDAs = getUDAs!(Symbol, UDA);}))
+        enum UDAs = getUDAs!(Symbol, UDA);
+    else
+        enum UDAs = [UDA.init];
+    
     static if(UDAs.length == 0)
         static assert(false, "The symbol `"~Symbol.stringof~"` does not have the `@"~UDA.stringof~"` UDA");
     else static if(UDAs.length > 1)


### PR DESCRIPTION
TLDR; `@Command(null, "desc")` -> `@CommandDefault("desc")`

Old syntax now fails an assert with a user-friendly message:

```
Null command names are deprecated, please use @CommandDefault instead.
```

Closes #6 