### PR TITLE
Implement @ArgValidator

### DIFF
--- a/examples/08-arg-binder-validation/source/commands.d
+++ b/examples/08-arg-binder-validation/source/commands.d
@@ -8,6 +8,7 @@ alias Even = Flag!"even";
 // This is a validation struct
 //
 // It performs value validation (`onValidate`)
+@ArgValidator
 struct Is
 {
     import std.traits : isNumeric;

--- a/source/jaster/cli/core.d
+++ b/source/jaster/cli/core.d
@@ -1360,6 +1360,7 @@ version(unittest)
         );
     }
 
+    @ArgValidator
     private struct Expect(T)
     {
         T value;


### PR DESCRIPTION
Closes #25 

Arg validator types must now be decorated with `@ArgValidator` in order to be considered, this prevents conflict with external UDAs.

Now that there's a clear marker for what an arg validator is, the ArgBinder will assume that the UDA's interface is correct, and will allow the compiler to generate an error if it's not, instead of just silently skipping over it:

```
source\jaster\cli\binder.d(168,44): Error: function jaster.cli.binder.__unittest_L302_C1.Dummy.onPreValidate(ref string error) is not callable using argument types (string, string)
source\jaster\cli\binder.d(168,44):        expected 1 argument(s), not 2
source\jaster\cli\binder.d(324,56): Error: template instance jaster.cli.binder.ArgBinder!(binder).ArgBinder.bind!(int, Dummy) error instantiating
```

This also makes the code versioned under `JCLI_BinderCompilerErrors` useless, so it has been removed.

This behaviour also means post-bind validators that use a templated `onValidate` function will get proper compiler errors, instead of just being skipped over silently in the event of an error.

Other changes to validators and the ArgBinder are going to be done separately.